### PR TITLE
Auth implementation for HTTP and WebSockets connections

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,6 +59,9 @@ dependencies {
         exclude(group = "org.json", module = "json")
     }
 
+    //shared prefs / crypto
+    implementation("androidx.security:security-crypto-ktx:1.1.0-alpha06")
+
     //firebase
     implementation("com.firebaseui:firebase-ui-auth:8.0.0")
     implementation("com.google.firebase:firebase-auth-ktx")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("kotlin-kapt")
     id("com.google.dagger.hilt.android")
+    id("com.google.gms.google-services")
     id("org.jetbrains.kotlin.plugin.compose") version "2.0.0" // this version matches your Kotlin version
     kotlin("plugin.serialization") version "1.9.22"
 }
@@ -57,6 +58,11 @@ dependencies {
     implementation("io.socket:socket.io-client:2.1.1") {
         exclude(group = "org.json", module = "json")
     }
+
+    //firebase
+    implementation("com.firebaseui:firebase-ui-auth:8.0.0")
+    implementation("com.google.firebase:firebase-auth-ktx")
+    implementation(platform("com.google.firebase:firebase-bom:33.8.0"))
 
     //timber
     implementation("com.jakewharton.timber:timber:5.0.1")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
     <application
-        android:name=".di.Trandroidlator"
+        android:name=".di.InterpApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
@@ -18,16 +18,23 @@
         android:networkSecurityConfig="@xml/network_security_config"
         tools:targetApi="34">
         <activity
-            android:name=".ui.MainActivity"
+            android:name=".ui.AuthActivity"
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.Trandroidlator"
-            android:launchMode="singleInstance">
+            android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+        <activity
+            android:name=".ui.MainActivity"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:theme="@style/Theme.Trandroidlator"
+            android:launchMode="singleTask">
         </activity>
     </application>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,7 +31,6 @@
         </activity>
         <activity
             android:name=".ui.MainActivity"
-            android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.Trandroidlator"
             android:launchMode="singleTask">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.Trandroidlator"
-            android:launchMode="singleTask">
+            android:launchMode="singleInstance">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/critt/trandroidlator/data/LanguageSource.kt
+++ b/app/src/main/java/com/critt/trandroidlator/data/LanguageSource.kt
@@ -38,6 +38,8 @@ fun <T> toResultFlow(call: suspend () -> Response<T>?): Flow<ApiResult<T>?> {
                 }
             }
         } catch (e: Exception) {
+            Timber.e(e.message)
+            e.printStackTrace()
             emit(ApiResult.Error(e.toString()))
         }
 

--- a/app/src/main/java/com/critt/trandroidlator/data/SessionManager.kt
+++ b/app/src/main/java/com/critt/trandroidlator/data/SessionManager.kt
@@ -28,7 +28,7 @@ class SessionManager @Inject constructor(
     }
 
     fun getAuthToken(): String? {
-        return sharedPreferences.getString("PREFS_KEY_FB_TOKEN", null)
+        return sharedPreferences.getString(PREFS_KEY_FB_TOKEN, null)
     }
 
     fun clearAuthToken() {

--- a/app/src/main/java/com/critt/trandroidlator/data/SessionManager.kt
+++ b/app/src/main/java/com/critt/trandroidlator/data/SessionManager.kt
@@ -1,0 +1,35 @@
+package com.critt.trandroidlator.data
+
+import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import com.critt.trandroidlator.util.Constants.PREFS_KEY_FB_TOKEN
+import com.critt.trandroidlator.util.Constants.PREFS_NAME
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SessionManager @Inject constructor(
+    @ApplicationContext context: Context
+) {
+    var token: String? = null
+
+    private val sharedPreferences = EncryptedSharedPreferences.create(
+        context,
+        PREFS_NAME,
+        MasterKey.Builder(context).setKeyScheme(MasterKey.KeyScheme.AES256_GCM).build(),
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+    )
+
+    fun saveAuthToken(token: String) {
+        sharedPreferences.edit().putString(PREFS_KEY_FB_TOKEN, token).apply()
+        this.token = token
+    }
+
+    fun clearAuthToken() {
+        token = null
+        sharedPreferences.edit().remove(PREFS_KEY_FB_TOKEN).apply()
+    }
+}

--- a/app/src/main/java/com/critt/trandroidlator/data/SessionManager.kt
+++ b/app/src/main/java/com/critt/trandroidlator/data/SessionManager.kt
@@ -13,7 +13,7 @@ import javax.inject.Singleton
 class SessionManager @Inject constructor(
     @ApplicationContext context: Context
 ) {
-    var token: String? = null
+    //TODO: Add token to http requests with an interceptor, and to sockets messages somehow (would be cool if it followed a similar pattern)
 
     private val sharedPreferences = EncryptedSharedPreferences.create(
         context,
@@ -23,13 +23,15 @@ class SessionManager @Inject constructor(
         EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
     )
 
-    fun saveAuthToken(token: String) {
+    fun setAuthToken(token: String) {
         sharedPreferences.edit().putString(PREFS_KEY_FB_TOKEN, token).apply()
-        this.token = token
+    }
+
+    fun getAuthToken(): String? {
+        return sharedPreferences.getString("PREFS_KEY_FB_TOKEN", null)
     }
 
     fun clearAuthToken() {
-        token = null
         sharedPreferences.edit().remove(PREFS_KEY_FB_TOKEN).apply()
     }
 }

--- a/app/src/main/java/com/critt/trandroidlator/data/TranslationSource.kt
+++ b/app/src/main/java/com/critt/trandroidlator/data/TranslationSource.kt
@@ -8,17 +8,27 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 
-class TranslationSource {
+class TranslationSource(
+    private val sessionManager: SessionManager
+) {
     private var socketSubject: Socket? = null
     private var socketObject: Socket? = null
 
     fun connectObject(languageSubject: String, languageObject: String): Flow<SpeechData> {
-        socketObject = IO.socket(BuildConfig.API_BASE_URL + "object")
+        /**
+         * https://socketio.github.io/socket.io-client-java/initialization.html#auth
+         * */
+        val options: IO.Options = IO.Options.builder().setAuth(mapOf("token" to sessionManager.getAuthToken())).build()
+        socketObject = IO.socket(BuildConfig.API_BASE_URL + "object", options)
         return initSocket(socketObject, getTranscriptionConfig(languageObject, languageSubject))
     }
 
     fun connectSubject(languageSubject: String, languageObject: String): Flow<SpeechData> {
-        socketSubject = IO.socket(BuildConfig.API_BASE_URL + "subject")
+        /**
+         * https://socketio.github.io/socket.io-client-java/initialization.html#auth
+         * */
+        val options: IO.Options = IO.Options.builder().setAuth(mapOf("token" to sessionManager.getAuthToken())).build()
+        socketSubject = IO.socket(BuildConfig.API_BASE_URL + "subject", options)
         return initSocket(socketSubject, getTranscriptionConfig(languageSubject, languageObject))
     }
 

--- a/app/src/main/java/com/critt/trandroidlator/di/AudioModule.kt
+++ b/app/src/main/java/com/critt/trandroidlator/di/AudioModule.kt
@@ -1,0 +1,16 @@
+package com.critt.trandroidlator.di
+
+import com.critt.trandroidlator.data.AudioSource
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AudioModule {
+    @Provides
+    @Singleton
+    fun provideAudioSource(): AudioSource = AudioSource()
+}

--- a/app/src/main/java/com/critt/trandroidlator/di/HttpModule.kt
+++ b/app/src/main/java/com/critt/trandroidlator/di/HttpModule.kt
@@ -3,10 +3,12 @@ package com.critt.trandroidlator.di
 
 import com.critt.trandroidlator.BuildConfig
 import com.critt.trandroidlator.data.LanguageSource
+import com.critt.trandroidlator.data.SessionManager
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import javax.inject.Singleton
@@ -19,8 +21,22 @@ object HttpModule {
 
     @Provides
     @Singleton
-    fun provideRetrofit(baseUrl: String): Retrofit = Retrofit.Builder()
+    fun provideHttpClient(sessionManager: SessionManager): OkHttpClient {
+        return OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                val request = chain.request().newBuilder()
+                    .addHeader("Authorization", "Bearer ${sessionManager.getAuthToken()}")
+                    .build()
+                chain.proceed(request)
+            }
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideRetrofit(baseUrl: String, httpClient: OkHttpClient): Retrofit = Retrofit.Builder()
         .baseUrl(baseUrl)
+        .client(httpClient)
         .addConverterFactory(GsonConverterFactory.create())
         .build()
 

--- a/app/src/main/java/com/critt/trandroidlator/di/HttpModule.kt
+++ b/app/src/main/java/com/critt/trandroidlator/di/HttpModule.kt
@@ -2,9 +2,7 @@ package com.critt.trandroidlator.di
 
 
 import com.critt.trandroidlator.BuildConfig
-import com.critt.trandroidlator.data.AudioSource
 import com.critt.trandroidlator.data.LanguageSource
-import com.critt.trandroidlator.data.TranslationSource
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -15,7 +13,7 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-object NetworkModule {
+object HttpModule {
     @Provides
     fun provideBaseUrl() = BuildConfig.API_BASE_URL
 
@@ -29,12 +27,4 @@ object NetworkModule {
     @Provides
     @Singleton
     fun provideLanguageSource(retrofit: Retrofit): LanguageSource = retrofit.create(LanguageSource::class.java)
-
-    @Provides
-    @Singleton
-    fun provideSocketsService(): TranslationSource = TranslationSource()
-
-    @Provides
-    @Singleton
-    fun provideAudioSource(): AudioSource = AudioSource()
 }

--- a/app/src/main/java/com/critt/trandroidlator/di/InterpApp.kt
+++ b/app/src/main/java/com/critt/trandroidlator/di/InterpApp.kt
@@ -1,13 +1,15 @@
 package com.critt.trandroidlator.di
 
 import android.app.Application
+import com.google.firebase.FirebaseApp
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
 
 @HiltAndroidApp
-class Trandroidlator : Application() {
+class InterpApp : Application() {
     override fun onCreate() {
         super.onCreate()
         Timber.plant(Timber.DebugTree())
+        FirebaseApp.initializeApp(this)
     }
 }

--- a/app/src/main/java/com/critt/trandroidlator/di/NetworkModule.kt
+++ b/app/src/main/java/com/critt/trandroidlator/di/NetworkModule.kt
@@ -15,7 +15,7 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-object DataModule {
+object NetworkModule {
     @Provides
     fun provideBaseUrl() = BuildConfig.API_BASE_URL
 

--- a/app/src/main/java/com/critt/trandroidlator/di/NetworkModule.kt
+++ b/app/src/main/java/com/critt/trandroidlator/di/NetworkModule.kt
@@ -28,7 +28,7 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideRESTService(retrofit: Retrofit): LanguageSource = retrofit.create(LanguageSource::class.java)
+    fun provideLanguageSource(retrofit: Retrofit): LanguageSource = retrofit.create(LanguageSource::class.java)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/critt/trandroidlator/di/SocketsModule.kt
+++ b/app/src/main/java/com/critt/trandroidlator/di/SocketsModule.kt
@@ -1,5 +1,6 @@
 package com.critt.trandroidlator.di
 
+import com.critt.trandroidlator.data.SessionManager
 import com.critt.trandroidlator.data.TranslationSource
 import dagger.Module
 import dagger.Provides
@@ -12,5 +13,5 @@ import javax.inject.Singleton
 object SocketsModule {
     @Provides
     @Singleton
-    fun provideSocketsService(): TranslationSource = TranslationSource()
+    fun provideSocketsService(sessionManager: SessionManager): TranslationSource = TranslationSource(sessionManager)
 }

--- a/app/src/main/java/com/critt/trandroidlator/di/SocketsModule.kt
+++ b/app/src/main/java/com/critt/trandroidlator/di/SocketsModule.kt
@@ -1,0 +1,16 @@
+package com.critt.trandroidlator.di
+
+import com.critt.trandroidlator.data.TranslationSource
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object SocketsModule {
+    @Provides
+    @Singleton
+    fun provideSocketsService(): TranslationSource = TranslationSource()
+}

--- a/app/src/main/java/com/critt/trandroidlator/ui/AuthActivity.kt
+++ b/app/src/main/java/com/critt/trandroidlator/ui/AuthActivity.kt
@@ -1,0 +1,56 @@
+package com.critt.trandroidlator.ui
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.firebase.ui.auth.AuthUI
+import com.firebase.ui.auth.FirebaseAuthUIActivityResultContract
+import com.firebase.ui.auth.data.model.FirebaseAuthUIAuthenticationResult
+import com.google.firebase.auth.FirebaseAuth
+import timber.log.Timber
+
+class AuthActivity : AppCompatActivity() {
+    private val signInLauncher = registerForActivityResult(
+        FirebaseAuthUIActivityResultContract()
+    ) { result ->
+        onSignInResult(result)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        createSignInIntent()
+    }
+
+    private fun createSignInIntent() {
+        Timber.d("createSignInIntent()")
+        // Choose authentication providers
+        val providers = arrayListOf(
+            AuthUI.IdpConfig.EmailBuilder().setAllowNewAccounts(false).build(),
+        )
+
+        // Create and launch sign-in intent
+        val signInIntent = AuthUI.getInstance()
+            .createSignInIntentBuilder()
+            .setAvailableProviders(providers)
+            .build()
+        signInLauncher.launch(signInIntent)
+    }
+
+    private fun onSignInResult(result: FirebaseAuthUIAuthenticationResult) {
+        Timber.d("onSignInResult()")
+
+        val response = result.idpResponse
+        if (result.resultCode == RESULT_OK) {
+            // Successfully signed in
+            val user = FirebaseAuth.getInstance().currentUser
+            // ...
+            //TODO: Store session material and launch MainActivity OR
+            //TODO: Launch MainActivity with session material in the bundle and handle session state there
+        } else {
+            // Sign in failed. If response is null the user canceled the
+            // sign-in flow using the back button. Otherwise check
+            // response.getError().getErrorCode() and handle the error.
+            // ...
+            //TODO: Handle auth failure
+        }
+    }
+}

--- a/app/src/main/java/com/critt/trandroidlator/ui/AuthViewModel.kt
+++ b/app/src/main/java/com/critt/trandroidlator/ui/AuthViewModel.kt
@@ -1,0 +1,57 @@
+package com.critt.trandroidlator.ui
+
+import androidx.lifecycle.ViewModel
+import com.critt.trandroidlator.data.SessionManager
+import com.google.firebase.auth.FirebaseUser
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import androidx.lifecycle.viewModelScope
+import com.critt.trandroidlator.util.getIdTokenSafely
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+
+@HiltViewModel
+class AuthViewModel @Inject constructor(
+    private val sessionManager: SessionManager
+) : ViewModel() {
+
+    private val _authState = MutableStateFlow<AuthState>(AuthState.Unauthenticated)
+    val authState: StateFlow<AuthState> get() = _authState
+
+    private val _toastMessage = MutableStateFlow<String?>(null)
+    val toastMessage: StateFlow<String?> get() = _toastMessage
+
+    fun initSession(user: FirebaseUser) {
+        viewModelScope.launch(context = Dispatchers.IO) {
+            val result = user.getIdTokenSafely(true)
+
+            result.onSuccess { tokenResult ->
+                tokenResult.token?.let {
+                    sessionManager.saveAuthToken(it)
+                    _authState.value = AuthState.Authenticated
+                } ?: run {
+                    showToast("Token is null")
+                    _authState.value = AuthState.Unauthenticated
+                }
+            }.onFailure { exc ->
+                exc.printStackTrace()
+                exc.message?.let {
+                    showToast(it)
+                }
+                _authState.value = AuthState.Unauthenticated
+            }
+        }
+    }
+
+    fun showToast(message: String) {
+        _toastMessage.value = message
+    }
+
+    sealed class AuthState {
+        data object Authenticated : AuthState()
+        data object Unauthenticated : AuthState()
+    }
+}

--- a/app/src/main/java/com/critt/trandroidlator/ui/AuthViewModel.kt
+++ b/app/src/main/java/com/critt/trandroidlator/ui/AuthViewModel.kt
@@ -30,7 +30,7 @@ class AuthViewModel @Inject constructor(
 
             result.onSuccess { tokenResult ->
                 tokenResult.token?.let {
-                    sessionManager.saveAuthToken(it)
+                    sessionManager.setAuthToken(it)
                     _authState.value = AuthState.Authenticated
                 } ?: run {
                     showToast("Token is null")

--- a/app/src/main/java/com/critt/trandroidlator/ui/MainActivity.kt
+++ b/app/src/main/java/com/critt/trandroidlator/ui/MainActivity.kt
@@ -24,6 +24,9 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.critt.trandroidlator.data.ApiResult
 import com.critt.trandroidlator.data.LanguageData
@@ -33,6 +36,8 @@ import com.critt.trandroidlator.data.defaultLangSubject
 import com.critt.trandroidlator.ui.components.DropdownSelector
 import com.critt.trandroidlator.ui.theme.TrandroidlatorTheme
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+import timber.log.Timber
 
 
 @AndroidEntryPoint

--- a/app/src/main/java/com/critt/trandroidlator/util/Constants.kt
+++ b/app/src/main/java/com/critt/trandroidlator/util/Constants.kt
@@ -1,0 +1,7 @@
+package com.critt.trandroidlator.util
+
+object Constants {
+    // Shared Preferences
+    const val PREFS_NAME = "enc_prefs"
+    const val PREFS_KEY_FB_TOKEN = "fb_token"
+}

--- a/app/src/main/java/com/critt/trandroidlator/util/Extensions.kt
+++ b/app/src/main/java/com/critt/trandroidlator/util/Extensions.kt
@@ -1,0 +1,13 @@
+package com.critt.trandroidlator.util
+
+import com.google.android.gms.tasks.Task
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.auth.GetTokenResult
+import kotlinx.coroutines.tasks.await
+
+suspend fun FirebaseUser.getIdTokenSafely(refresh: Boolean): Result<GetTokenResult> {
+    return runCatching {
+        val task: Task<GetTokenResult> = getIdToken(refresh)
+        task.await()
+    }
+}

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -6,7 +6,7 @@
         <domain includeSubdomains="true">192.168.0.32</domain>
         <domain includeSubdomains="true">0.0.0.0</domain>
         <domain includeSubdomains="true">appspot.com</domain>
-        <domain includeSubdomains="true">34.94.48.246</domain>
+        <domain includeSubdomains="true">34.102.51.156</domain>
         <trust-anchors>
             <certificates src="system" />
             <certificates src="user" />

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
     id("org.jetbrains.kotlin.android") version "2.0.0" apply false
     kotlin("plugin.serialization") version "1.9.22" apply false
     id("com.google.dagger.hilt.android") version "2.51.1" apply false
+    id("com.google.gms.google-services") version "4.4.2" apply false
 }


### PR DESCRIPTION
#### Background
This is the client partner to [this PR](url), which added auth to the backend used by this application. That PR adds auth for the sockets channels only, and left the HTTP routes public. Eventually that service will require a valid JWT for HTTP requests just like it now does with connections to sockets channels. This PR implements sockets auth on the opening of sockets channels using [socketio](https://socketio.github.io/socket.io-client-java/initialization.html#auth), and also adds auth headers to HTTP requests.

#### What's in the PR?
- A new `SessionManager` singleton, which holds and provides access to the active [Firebase ID token](https://firebase.google.com/docs/auth/admin/verify-id-tokens#retrieve_id_tokens_on_clients). The token is stored persistently with `EncryptedSharedPreferences`.
- `TranslationSource`'s `connect*` functions now inject this token into the space that socketio provides for arbitrary connection metadata.
- 'provideHttpClient()' now configures the `OkHttpClient` to add auth headers.
- Added `AuthActivity` and `AuthViewModel`, which amount to a simple login UI using [FirebaseUI](https://firebase.google.com/docs/auth/android/firebaseui).

##### Other changes
- Split `DataModule` into `AudioModule`, `HttpModule`, and `SocketsModule`.
- Renamed ` Trandroidlator` -> `InterpApp`
